### PR TITLE
Error box from static row to modal (#33)

### DIFF
--- a/src/main/resources/static/css/front.css
+++ b/src/main/resources/static/css/front.css
@@ -1,6 +1,25 @@
 body {
     width: 99%;
 }
+
+@media all and (max-width: 768px) {
+    .mini-row {
+        padding: 1px;
+    }
+}
+
+@media all and (min-width: 768px) {
+    .mini-row {
+        padding: 5px;
+    }
+}
+
+@media (min-width: 992px) {
+    .mini-row {
+        padding: 15px;
+    }
+}
+
 .main {
     background: #f0f0f0;
     border: 1px solid #e3e3e3;

--- a/src/main/resources/static/js/front.js
+++ b/src/main/resources/static/js/front.js
@@ -27,11 +27,6 @@ function sendLink(long_url) {
     doPost(storeLinkRoute, json, onSuccessStoreLink, onFailStoreLink);
 }
 
-function onAlertClose() {
-    $("#errorText").html("");
-    $("#errorModal").modal('hide');
-}
-
 function onSuccessStoreLink(data, textStatus, jqXHR) {
     cleanErrors();
     cleanForm();
@@ -127,7 +122,6 @@ function handleForm(e) {
 
 $(document).ready(function () {
     $("#shortenIt").on('click', handleForm);
-    $("#errorClose").on('click', onAlertClose);
     $('[data-toggle="tooltip"]').tooltip();
     $("#copyLink").on('click', copyLinkToClipboard);
 });

--- a/src/main/resources/static/js/front.js
+++ b/src/main/resources/static/js/front.js
@@ -1,6 +1,6 @@
 function cleanErrors() {
     $("#errorText").html("");
-    $("#error").addClass('invisible');
+    $("#errorModal").modal('hide');
 }
 
 function cleanForm() {
@@ -14,7 +14,7 @@ function cleanResults(){
 
 function showError(errorMessage) {
     $("#errorText").html(errorMessage);
-    $("#error").removeClass('invisible');
+    $("#errorModal").modal('show');
 }
 
 function sendLink(long_url) {
@@ -29,7 +29,7 @@ function sendLink(long_url) {
 
 function onAlertClose() {
     $("#errorText").html("");
-    $("#error").addClass('invisible');
+    $("#errorModal").modal('hide');
 }
 
 function onSuccessStoreLink(data, textStatus, jqXHR) {

--- a/src/main/resources/templates/index.ftl
+++ b/src/main/resources/templates/index.ftl
@@ -97,5 +97,20 @@
     </div><!-- /.modal-dialog -->
 </div><!-- /.modal -->
 
+<!-- Error modal -->
+<div class="modal fade" id="errorModal">
+    <div class="modal-dialog modal-sm" role="document">
+        <div class="modal-body modal-content alert alert-danger">
+            <button id="errorClose" type="button" class="close" data-dismiss="modal" aria-label="Close">
+                <span aria-hidden="true" class="glyphicon glyphicon-remove"></span>
+            </button>
+            <span class="glyphicon glyphicon-remove-sign" aria-hidden="true"></span>
+            <p class="in-same-line">
+                <strong>Hups! </strong><span id="errorText"></span>
+            </p>
+        </div><!-- /.modal-body -->
+    </div><!-- /.modal-dialog -->
+</div><!-- /.modal -->
+
 </body>
 </html>

--- a/src/main/resources/templates/index.ftl
+++ b/src/main/resources/templates/index.ftl
@@ -18,12 +18,13 @@
 
 <!-- Error Div -->
 <div class="container-fluid">
-    <div id="first" class="row">
+    <div id="first" class="row mini-row">
         <div class="col-xs-0 col-sm-1 col-md-2 col-lg-3"></div>
-        <div id="error" class="alert alert-danger col-xs-12 col-sm-10 col-md-8 col-lg-6 invisible">
-            <button id="errorClose" class="close" type="button" aria-hidden="true">&times;</button>
-            <strong>Hups! </strong><span id="errorText"></span>
-        </div>
+        <!-- There will be authorization line -->
+    <#--<div id="error" class="alert alert-danger col-xs-12 col-sm-10 col-md-8 col-lg-6 invisible">
+        <button id="errorClose" class="close" type="button" aria-hidden="true">&times;</button>
+        <strong>Hups! </strong><span id="errorText"></span>
+    </div>-->
         <div class="col-xs-0 col-sm-1 col-md-2 col-lg-3"></div>
     </div>
     <!-- Main Div -->

--- a/src/test/java/ee/yals/test/selenide/front/CorrectInputTest.java
+++ b/src/test/java/ee/yals/test/selenide/front/CorrectInputTest.java
@@ -6,7 +6,7 @@ import org.junit.Test;
 
 import static com.codeborne.selenide.Condition.*;
 import static com.codeborne.selenide.Selenide.open;
-import static ee.yals.test.utils.selectors.FrontSelectors.ErrorRow.ERROR_DIV;
+import static ee.yals.test.utils.selectors.FrontSelectors.ErrorRow.ERROR_MODAL;
 import static ee.yals.test.utils.selectors.FrontSelectors.ErrorRow.ERROR_TEXT;
 import static ee.yals.test.utils.selectors.FrontSelectors.MainRow.LONG_URL_INPUT;
 import static ee.yals.test.utils.selectors.FrontSelectors.ResultRow.*;
@@ -63,7 +63,7 @@ public class CorrectInputTest extends UITest {
 
         LONG_URL_INPUT.shouldBe(empty);
 
-        ERROR_DIV.shouldNotBe(visible);
+        ERROR_MODAL.shouldNotBe(visible);
         ERROR_TEXT.shouldBe(empty);
     }
 }

--- a/src/test/java/ee/yals/test/selenide/front/IncorrectInputTest.java
+++ b/src/test/java/ee/yals/test/selenide/front/IncorrectInputTest.java
@@ -99,7 +99,7 @@ public class IncorrectInputTest extends UITest {
     }
 
     private void errorBoxShouldAppear() {
-        ERROR_DIV.shouldBe(visible);
+        ERROR_MODAL.shouldBe(visible);
         ERROR_TEXT.shouldNotBe(empty);
         ERROR_CLOSE.shouldBe(visible);
     }

--- a/src/test/java/ee/yals/test/selenide/front/MultiStepTest.java
+++ b/src/test/java/ee/yals/test/selenide/front/MultiStepTest.java
@@ -11,7 +11,7 @@ import org.openqa.selenium.Keys;
 import static com.codeborne.selenide.Condition.*;
 import static com.codeborne.selenide.Selenide.open;
 import static ee.yals.test.utils.selectors.FrontSelectors.ErrorRow.ERROR_CLOSE;
-import static ee.yals.test.utils.selectors.FrontSelectors.ErrorRow.ERROR_DIV;
+import static ee.yals.test.utils.selectors.FrontSelectors.ErrorRow.ERROR_MODAL;
 import static ee.yals.test.utils.selectors.FrontSelectors.MainRow.LONG_URL_INPUT;
 import static ee.yals.test.utils.selectors.FrontSelectors.OverallRow.OVERALL_LINKS_NUMBER;
 import static ee.yals.test.utils.selectors.FrontSelectors.ResultRow.*;
@@ -29,21 +29,21 @@ public class MultiStepTest extends UITest {
     }
 
     @Test
-    public void closeButtonReallyClosesErrorDiv() {
+    public void closeButtonReallyClosesErrorModal() {
         pasteValueInFormAndSubmitIt(" ");
 
         ERROR_CLOSE.click();
-        ERROR_DIV.shouldNotBe(visible);
+        ERROR_MODAL.shouldNotBe(visible);
 
     }
 
     @Test
-    public void closeButtonClosesErrorDivButNotRemoves() {
+    public void closeButtonClosesErrorModalButNotRemoves() {
         pasteValueInFormAndSubmitIt(" ");
 
         ERROR_CLOSE.click();
-        ERROR_DIV.shouldNotBe(visible);
-        ERROR_DIV.shouldBe(exist);
+        ERROR_MODAL.shouldNotBe(visible);
+        ERROR_MODAL.shouldBe(exist);
     }
 
     @Test

--- a/src/test/java/ee/yals/test/selenide/front/VisibleStateTest.java
+++ b/src/test/java/ee/yals/test/selenide/front/VisibleStateTest.java
@@ -9,7 +9,7 @@ import org.junit.Test;
 
 import static com.codeborne.selenide.Condition.*;
 import static com.codeborne.selenide.Selenide.*;
-import static ee.yals.test.utils.selectors.FrontSelectors.ErrorRow.ERROR_DIV;
+import static ee.yals.test.utils.selectors.FrontSelectors.ErrorRow.ERROR_MODAL;
 import static ee.yals.test.utils.selectors.FrontSelectors.MainRow.*;
 import static ee.yals.test.utils.selectors.FrontSelectors.OverallRow.*;
 import static ee.yals.test.utils.selectors.FrontSelectors.ResultRow.RESULT_DIV;
@@ -29,7 +29,7 @@ public class VisibleStateTest extends UITest {
 
     @Test
     public void errorBlockIsHidden() {
-        ERROR_DIV.shouldNotBe(visible);
+        ERROR_MODAL.shouldNotBe(visible);
     }
 
     @Test

--- a/src/test/java/ee/yals/test/utils/selectors/FrontSelectors.java
+++ b/src/test/java/ee/yals/test/utils/selectors/FrontSelectors.java
@@ -11,7 +11,7 @@ import static com.codeborne.selenide.Selenide.$;
  */
 public class FrontSelectors {
     public static class ErrorRow {
-        public static final SelenideElement ERROR_DIV = $("#error");
+        public static final SelenideElement ERROR_MODAL = $("#errorModal");
         public static final SelenideElement ERROR_TEXT = $("#errorText");
         public static final SelenideElement ERROR_CLOSE = $("#errorClose");
     }


### PR DESCRIPTION
#33 Rewrite Error box from static row to modal
- first row redesigned to mini-row
- big tests refactoring (selectors moved to separate class)
- error row content moved to error modal
- adjusted tests